### PR TITLE
iOS 9.3.3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 ARCHS = armv7 arm64
 include theos/makefiles/common.mk
 
-TWEAK_NAME = EasyRespring2
-EasyRespring2_FILES = Tweak.xm
-EasyRespring2_FRAMEWORKS = UIKit
-EasyRespring2_LDFLAGS += -Wl,-segalign,4000
+TWEAK_NAME = EasyRespring
+EasyRespring_FILES = Tweak.xm
+EasyRespring_FRAMEWORKS = UIKit
+EasyRespring_LDFLAGS += -Wl,-segalign,4000
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,10 +1,10 @@
 #include <substrate.h>
-#include <UIKit/UIKit.h>
 
 typedef void* CDUnknownBlockType;
 
-@interface SpringBoard : NSObject
-- (void)_relaunchSpringBoardNow;
+@interface FBSystemService : NSObject
++(id)sharedInstance;
+-(void)exitAndRelaunch:(BOOL)arg1;
 @end
 
 @interface SBDisplayItem : NSObject
@@ -21,7 +21,7 @@ typedef void* CDUnknownBlockType;
 
 - (void)switcherScroller:(id)arg1 displayItemWantsToBeRemoved:(SBDisplayItem *)arg2 {
     if ([arg2.displayIdentifier isEqualToString:@"com.apple.springboard"]) {
-        [(SpringBoard *)[UIApplication sharedApplication] _relaunchSpringBoardNow];
+        [[%c(FBSystemService) sharedInstance] exitAndRelaunch:YES];
     }
     %orig;
 }
@@ -38,7 +38,7 @@ typedef void* CDUnknownBlockType;
 
 - (void)removeDisplayItem:(SBDisplayItem *)arg1 updateScrollPosition:(_Bool)arg2 forReason:(long long)arg3 completion:(CDUnknownBlockType)arg4 {
     if ([arg1.displayIdentifier isEqualToString:@"com.apple.springboard"]) {
-        [(SpringBoard *)[UIApplication sharedApplication] _relaunchSpringBoardNow];
+        [[%c(FBSystemService) sharedInstance] exitAndRelaunch:YES];
     }
     %orig;
 }

--- a/control
+++ b/control
@@ -4,6 +4,6 @@ Depends: mobilesubstrate
 Version: 1.1
 Architecture: iphoneos-arm
 Description: Respring your device by removing the springboard card from the app switcher. supports ios 8 and 9
-Maintainer: DGh0st
-Author: DGh0st
+Maintainer: Satori
+Author: Satori
 Section: Tweaks

--- a/control
+++ b/control
@@ -1,9 +1,9 @@
 Package: org.satorify.easyrespring
 Name: EasyRespring
 Depends: mobilesubstrate
-Version: 1.0
+Version: 1.1
 Architecture: iphoneos-arm
 Description: Respring your device by removing the springboard card from the app switcher. supports ios 8 and 9
-Maintainer: Satori
-Author: Satori
+Maintainer: DGh0st
+Author: DGh0st
 Section: Tweaks


### PR DESCRIPTION
SpringBoard's _relaunchSpringBoardNow ceased to exist in iOS 9.3.3 so changing it to FBSystemService's exitAndRelaunch should not cause crashes to safemode on iOS 9.3.3. Also note that FBSystemService's exitAndRelaunch exist from iOS 8.0 to iOS 9.3.3 so no issues should be caused by changing it for iOS 8.0 switcher as well.
